### PR TITLE
Adding workaround for hostname swapping issue in OpenStack kube-up provider

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/fragments/hostname-hack.sh
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/hostname-hack.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Workaround for this, which has been fixed but not widely distributed: https://bugs.launchpad.net/cloud-init/+bug/1246485
+# See also http://blog.oddbit.com/2014/12/10/cloudinit-and-the-case-of-the-changing-hostname/
+hostname > /etc/hostname

--- a/cluster/openstack-heat/kubernetes-heat/fragments/hostname-hack.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/hostname-hack.yaml
@@ -1,0 +1,9 @@
+#cloud-config
+merge_how: dict(recurse_array)+list(append)
+
+write_files:
+  - path: /etc/cloud/cloud.cfg.d/99_hostname.cfg
+    owner: "root:root"
+    permissions: "0644"
+    content: |
+      preserve_hostname: true

--- a/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
@@ -242,6 +242,18 @@ resources:
             "$SOCKS_PROXY": {get_param: socks_proxy }
             "$NO_PROXY": {get_param: no_proxy }
 
+  hostname_hack:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: ungrouped
+      config: {get_file: fragments/hostname-hack.yaml}
+
+  hostname_hack_script:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: ungrouped
+      config: {get_file: fragments/hostname-hack.sh}
+
   kube_user:
     type: OS::Heat::SoftwareConfig
     properties:
@@ -299,6 +311,8 @@ resources:
       parts:
         - config: {get_resource: write_heat_params}
         - config: {get_resource: proxy_config}
+        - config: {get_resource: hostname_hack}
+        - config: {get_resource: hostname_hack_script}
         - config: {get_resource: kube_user}
         - config: {get_resource: provision_network_master}
         - config: {get_resource: deploy_kube_auth_files_master}

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -165,6 +165,18 @@ resources:
             "$SOCKS_PROXY": {get_param: socks_proxy }
             "$NO_PROXY": {get_param: no_proxy }
 
+  hostname_hack:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: ungrouped
+      config: {get_file: fragments/hostname-hack.yaml}
+
+  hostname_hack_script:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: ungrouped
+      config: {get_file: fragments/hostname-hack.sh}
+
   kube_user:
     type: OS::Heat::SoftwareConfig
     properties:
@@ -220,6 +232,8 @@ resources:
       parts:
         - config: {get_resource: write_heat_params}
         - config: {get_resource: proxy_config}
+        - config: {get_resource: hostname_hack}
+        - config: {get_resource: hostname_hack_script}
         - config: {get_resource: kube_user}
         - config: {get_resource: provision_network_node}
         - config: {get_resource: deploy_kube_auth_files_node}


### PR DESCRIPTION
On reboot, minions hostname would change, causing issue querying Openstack API and registering with kube-apiserver. This would cause nodes to enter NotReady state.

This is due to a bug in cloud-init which has been patched but apparently not widely distributed.

Should be harmless on unaffected systems.
https://bugs.launchpad.net/cloud-init/+bug/1246485
http://blog.oddbit.com/2014/12/10/cloudinit-and-the-case-of-the-changing-hostname/